### PR TITLE
Make login optional

### DIFF
--- a/proboards_scraper/__main__.py
+++ b/proboards_scraper/__main__.py
@@ -50,12 +50,20 @@ def pbs_cli():
     Entrypoint for ``pbs`` (proboards scraper) tool.
     """
     parser = argparse.ArgumentParser()
+
     parser.add_argument("url", type=str, help="Homepage URL")
-    parser.add_argument("username", type=str, help="Login username")
-    parser.add_argument("password", type=str, help="Login password")
+
+    login_group = parser.add_argument_group("Login arguments")
+    login_group.add_argument(
+        "-u", "--username", type=str, help="Login username"
+    )
+    login_group.add_argument(
+        "-p", "--password", type=str, help="Login password"
+    )
+
     parser.add_argument(
         "-d", "--database", type=str, default="forum.db",
-        help="Path to database file"
+        help="Path to database file (default forum.db)"
     )
     parser.add_argument(
         "-U", "--no-users", action="store_true", dest="skip_users",
@@ -68,12 +76,22 @@ def pbs_cli():
     )
     args = parser.parse_args()
 
+    if (
+        (args.username and not args.password)
+        or (args.password and not args.username)
+    ):
+        print(
+            "If providing login credentials, both username and password "
+            "are required"
+        )
+        exit(1)
+
     configure_logging(args.verbosity)
 
     args.url = args.url.rstrip("/")
     proboards_scraper.scrape_site(
-        args.url, args.username, args.password, args.database,
-        skip_users=args.skip_users
+        args.url, args.database, username=args.username,
+        password=args.password, skip_users=args.skip_users
     )
 
 

--- a/proboards_scraper/scraper.py
+++ b/proboards_scraper/scraper.py
@@ -426,13 +426,13 @@ async def get_content(
     categories = source.findAll("div", class_="container boards")
 
     for category in categories:
-        pass
+        title_bar = category.find("div", class_="title_wrapper")
 
     await content_queue.put(None)
 
 
 def scrape_site(
-    url: str, username: str, password: str, db_path: str,
+    url: str, db_path: str, username: str = None, password: str = None,
     skip_users: bool = False,
 ):
     """
@@ -444,12 +444,19 @@ def scrape_site(
         skip_users:
     """
     # Get cookies for parts of the site requiring login authentication.
-    logger.info(f"Logging in to {url}")
-    cookies = get_login_cookies(url, username, password)
 
-    # Create a persistent aiohttp login session from the cookies.
-    sess = get_login_session(cookies)
-    logger.info("Login successful")
+    if username and password:
+        logger.info(f"Logging in to {url}")
+        cookies = get_login_cookies(url, username, password)
+
+        # Create a persistent aiohttp login session from the cookies.
+        sess = get_login_session(cookies)
+        logger.info("Login successful")
+    else:
+        logger.info(
+            "Username and/or password not provided; proceeding without login"
+        )
+        sess = aiohttp.ClientSession()
 
     tasks = []
 


### PR DESCRIPTION
This PR makes login/authentication optional. Password-protected sections of the forum will not be able to be accessed if login credentials are not provided via the CLI (or call to the `scrape_site` function).