### PR TITLE
Query threads from command line interface

### DIFF
--- a/proboards_scraper/__main__.py
+++ b/proboards_scraper/__main__.py
@@ -183,6 +183,17 @@ def pbd_cli():
             pprint(board)
     elif action == "thread":
         result = db.query_threads(thread_id=value)
-        # TODO
+        thread = result
+        if thread is not None and "poll" in thread:
+            breakpoint()
+            poll_options = [
+                {"name": opt["name"], "votes": opt["votes"]}
+                for opt in thread["poll"]["options"]
+            ]
+            thread["poll"]["options"] = poll_options
+
+            poll_voters = [user["name"] for user in thread["poll"]["voters"]]
+            thread["poll"]["voters"] = poll_voters
+        pprint(thread)
     else:
         raise ValueError("Invalid action")

--- a/proboards_scraper/database/database.py
+++ b/proboards_scraper/database/database.py
@@ -29,11 +29,14 @@ def serialize(obj):
         if isinstance(obj, Board):
             dict_["moderators"] = serialize(list(obj.moderators))
         elif isinstance(obj, User):
-            avatar = serialize(obj.avatar[0])
-            dict_["avatar"] = {
-                "filename": avatar["filename"],
-                "url": avatar["url"],
-            }
+            avatar_ = None
+            if obj.avatar:
+                avatar = serialize(obj.avatar[0])
+                avatar_ = {
+                    "filename": avatar["filename"],
+                    "url": avatar["url"],
+                }
+            dict_["avatar"] = avatar_
 
         return dict_
     elif isinstance(obj, list):
@@ -228,6 +231,7 @@ class Database:
 
     def query_boards(self, board_id: int = None) -> Union[List[dict], dict]:
         """
+        TODO
         """
         result = self.session.query(Board)
 
@@ -241,3 +245,15 @@ class Database:
         else:
             result = result.all()
         return serialize(result)
+
+    def query_threads(self, thread_id: int = None) -> dict:
+        """
+        TODO
+        """
+        result = self.session.query(Thread)
+
+        if thread_id is not None:
+            result = result.filter_by(id=thread_id).first()
+            # TODO
+        else:
+            raise NotImplementedError

--- a/proboards_scraper/http_requests.py
+++ b/proboards_scraper/http_requests.py
@@ -148,7 +148,14 @@ async def download_image(
         },
     }
 
-    async with session.get(url) as response:
+    try:
+        response = await session.get(url, timeout=30)
+    except aiohttp.client_exceptions.ClientConnectorError as e:
+        logger.warning(
+            f"Failed to download image at {url}: {str(e)} "
+            "(it is likely the image or server no longer exists)"
+        )
+    else:
         ret["status"]["get"] = response.status
 
         if response.status == 200:
@@ -185,4 +192,5 @@ async def download_image(
                         await f.write(img)
                 else:
                     ret["status"]["exists"] = True
-    return ret
+    finally:
+        return ret

--- a/proboards_scraper/scraper_manager.py
+++ b/proboards_scraper/scraper_manager.py
@@ -53,6 +53,9 @@ class ScraperManager:
         self.user_queue = user_queue
 
     async def run(self):
+        """
+        TODO
+        """
         if self.user_queue is not None:
             all_users_added = False
             while not all_users_added:


### PR DESCRIPTION
This PR adds functionality to the `pbd` tool CLI to query threads and print results to the terminal.

It also addresses a few issues with scraping images and user avatars that were discovered while implementing the aforementioned functionality.