### PR TITLE
Feat/subsection

### DIFF
--- a/proboards_scraper/__main__.py
+++ b/proboards_scraper/__main__.py
@@ -55,8 +55,6 @@ def configure_logging(verbosity: int = 2):
         module_logger = logging.getLogger(module)
         module_logger.setLevel(import_log_level)
 
-    # Print to stdout in addition to logging to file.
-
 
 def pbs_cli():
     """
@@ -64,7 +62,10 @@ def pbs_cli():
     """
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("url", type=str, help="Homepage URL")
+    parser.add_argument(
+        "url", type=str,
+        help="URL for either the main page, a board, a thread, or a user"
+    )
 
     login_group = parser.add_argument_group("Login arguments")
     login_group.add_argument(

--- a/proboards_scraper/scraper.py
+++ b/proboards_scraper/scraper.py
@@ -551,9 +551,6 @@ async def scrape_board(url: str,manager: ScraperManager):
 
             await scrape_board(subboard_url, manager)
 
-    # TODO
-    return
-
     # Iterate over all board pages and add threads on each page to queue.
     thread_container = source.find("div", class_="container threads")
 

--- a/proboards_scraper/scraper_manager.py
+++ b/proboards_scraper/scraper_manager.py
@@ -52,6 +52,20 @@ class ScraperManager:
             user_queue = asyncio.Queue()
         self.user_queue = user_queue
 
+    def insert_guest(self, name):
+        """
+        TODO
+        """
+        guest = {
+            "id": -1,
+            "name": name,
+        }
+
+        # Get guest user id.
+        guest_db_obj = self.db.insert_guest(guest)
+        guest_id = guest_db_obj.id
+        return guest_id
+
     async def run(self):
         """
         TODO


### PR DESCRIPTION
This PR restructures the core scraper architecture to allow scraping either 1) the entire site, as before, 2) only user profile, 3) a specific user profile, 4) a board, or 5) a thread. We achieve this by determining which of the aforementioned five pages has been supplied from the URL, then wrapping the call to the relevant awaitable function in an awaitable helper that passes the URL and `ScraperManager` instance to said function, then puts `None` in the `ScraperManager`'s user queue, content queue, or both (to signal that processing for said queue has completed).

Closes #32 