### PR TITLE
Update regex to work with any TLD instead of just .com

### DIFF
--- a/proboards_scraper/scraper/utils.py
+++ b/proboards_scraper/scraper/utils.py
@@ -41,7 +41,7 @@ def split_url(url: str) -> Tuple[str, str]:
         is just the base/homepage URL).
     """
     url = url.rstrip("/")
-    expr = r"(^.*\.com)(/.*)?$"
+    expr = r"(^.*\.[a-z]+)(/.*)?$"
     match = re.match(expr, url)
     base_url, path = match.groups()
     return base_url, path


### PR DESCRIPTION
This PR updates the URL regex to work with any top-level domain instead of just `.com`. This enables the scraper to process domains like `boards.net`, for example.

Fixes #43.