### PR TITLE
Disable headless mode

### DIFF
--- a/proboards_scraper/http_requests.py
+++ b/proboards_scraper/http_requests.py
@@ -38,7 +38,7 @@ def get_chrome_driver() -> selenium.webdriver.Chrome:
         Headless Chrome driver.
     """
     chrome_opts = selenium.webdriver.ChromeOptions()
-    chrome_opts.headless = True
+    chrome_opts.headless = False
     driver = selenium.webdriver.Chrome(options=chrome_opts)
     return driver
 


### PR DESCRIPTION
The ProBoards login page refuses to load in headless mode but will load just fine when not in it. By disabling headless mode, the scraper is once again able to properly log into the forum it is scraping.